### PR TITLE
Add scroll to top button for articles

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -18,8 +18,8 @@ export default defineConfig({
   markdown: {
     shikiConfig: {
       themes: {
-        light: "github-light",
-        dark: "github-dark",
+        light: "github-light-default",
+        dark: "github-dark-default",
       },
     },
   },

--- a/src/assets/icons/arrow.svg
+++ b/src/assets/icons/arrow.svg
@@ -1,0 +1,22 @@
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class="size-4 rotate-90"
+  >
+    <line
+      x1="5"
+      y1="12"
+      x2="19"
+      y2="12"
+      class="translate-x-2 scale-x-0 transition-transform duration-300 ease-in-out group-hover:translate-x-0 group-hover:scale-x-100"
+    ></line>
+    <polyline
+      points="12 5 5 12 12 19"
+      class="translate-x-1 transition-transform duration-300 ease-in-out group-hover:translate-x-0"
+    ></polyline>
+  </svg>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -39,11 +39,7 @@ import Link from "./Link.astro";
         return;
       }
 
-      if (currScroll > lastScroll) {
-        header.classList.toggle(scrollClass, true);
-      } else if (currScroll < lastScroll) {
-        header.classList.toggle(scrollClass, false);
-      }
+      header.classList.toggle(scrollClass, currScroll > lastScroll);
 
       lastScroll = currScroll;
     },

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -34,7 +34,7 @@ import Link from "./Link.astro";
         return;
       }
 
-      if (currScroll <= 0) {
+      if (currScroll <= 0 || currScroll === lastScroll) {
         header.classList.remove(scrollClass);
         return;
       }

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -1,4 +1,5 @@
 ---
+import Arrow from "../assets/icons/arrow.svg";
 import type { CollectionEntry } from "astro:content";
 
 interface Props {
@@ -10,31 +11,16 @@ const { entry } = Astro.props;
 
 <a
   href={`/${entry.collection}/${entry.id}`}
-  class="group relative flex flex-nowrap rounded-lg border border-black/15 px-4 py-3 pr-10 hover:bg-black/5 hover:text-black dark:border-white/20 dark:hover:bg-white/5 dark:hover:text-white"
+  class="group flex flex-nowrap items-center gap-2 rounded-lg border border-neutral-200 py-3 pr-3 pl-5 hover:text-black dark:border-neutral-700 dark:hover:text-white"
 >
   <div class="flex flex-1 flex-col gap-1 overflow-x-hidden">
-    <div class="font-semibold">
+    <h3 class="font-semibold">
       {entry.data.title}
-    </div>
-    <div class="text-sm">
+    </h3>
+    <p class="text-sm">
       {entry.data.description}
-    </div>
+    </p>
   </div>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 24 24"
-    class="absolute top-1/2 right-2 size-5 -translate-y-1/2 fill-none stroke-current stroke-2"
-  >
-    <line
-      x1="5"
-      y1="12"
-      x2="19"
-      y2="12"
-      class="translate-x-3 scale-x-0 transition-transform duration-300 ease-in-out group-hover:translate-x-0 group-hover:scale-x-100"
-    ></line>
-    <polyline
-      points="12 5 19 12 12 19"
-      class="-translate-x-1 transition-transform duration-300 ease-in-out group-hover:translate-x-0"
-    ></polyline>
-  </svg>
+
+  <Arrow class="size-5 rotate-180" />
 </a>

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -22,5 +22,10 @@ const { entry } = Astro.props;
     </p>
   </div>
 
-  <Arrow class="size-5 rotate-180" />
+  <Arrow
+    class="size-5 rotate-180"
+    aria-hidden="true"
+    focusable="false"
+    role="img"
+  />
 </a>

--- a/src/components/Prose.astro
+++ b/src/components/Prose.astro
@@ -8,6 +8,7 @@ const { as: Component = "div" }: Props = Astro.props;
 
 <Component
   class:list={[
+    "relative",
     "prose",
     "max-w-none",
     "prose-neutral",

--- a/src/components/ScrollToTop.astro
+++ b/src/components/ScrollToTop.astro
@@ -1,0 +1,35 @@
+---
+import Arrow from "../assets/icons/arrow.svg";
+---
+
+<button
+  id="scroll-to-top"
+  class="group invisible sticky right-0 bottom-4 mr-2 ml-auto flex w-fit flex-nowrap items-center gap-1.5 rounded border border-neutral-200 bg-neutral-50 py-2 pr-2.5 pl-4 transition-colors duration-300 ease-in-out hover:text-black dark:border-neutral-700 dark:bg-neutral-900 dark:hover:text-white"
+>
+  <span class="text-sm"> Scroll to top </span>
+  <Arrow class="size-4 rotate-90" />
+</button>
+
+<script>
+  const scrollToTop = document.getElementById("scroll-to-top");
+
+  window.addEventListener(
+    "scroll",
+    () => {
+      if (!scrollToTop) return;
+
+      scrollToTop.classList.toggle(
+        "invisible",
+        !(window.scrollY > window.innerHeight / 2),
+      );
+    },
+    { passive: true },
+  );
+
+  scrollToTop?.addEventListener("click", () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  });
+</script>

--- a/src/components/ScrollToTop.astro
+++ b/src/components/ScrollToTop.astro
@@ -7,7 +7,12 @@ import Arrow from "../assets/icons/arrow.svg";
   class="group invisible sticky right-0 bottom-4 mr-2 ml-auto flex w-fit flex-nowrap items-center gap-1.5 rounded border border-neutral-200 bg-neutral-50 py-2 pr-2.5 pl-4 transition-colors duration-300 ease-in-out hover:text-black dark:border-neutral-700 dark:bg-neutral-900 dark:hover:text-white"
 >
   <span class="text-sm"> Scroll to top </span>
-  <Arrow class="size-4 rotate-90" />
+  <Arrow
+    class="size-4 rotate-90"
+    aria-hidden="true"
+    focusable="false"
+    role="img"
+  />
 </button>
 
 <script>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -7,6 +7,7 @@ import Layout from "../../layouts/Layout.astro";
 import ExternalLink from "../../components/ExternalLink.astro";
 import FormattedDate from "../../components/FormattedDate.astro";
 import PostComments from "../../components/PostComments.astro";
+import ScrollToTop from "../../components/ScrollToTop.astro";
 
 export const getStaticPaths = (async () => {
   const allPosts = await allBlogPosts();
@@ -27,6 +28,7 @@ const { Content, ...components } = await render(post);
     <h1>{post.data.title}</h1>
     <FormattedDate date={post.data.date} />
     <Content components={{ ...components, a: ExternalLink }} />
+    <ScrollToTop />
   </Prose>
 
   <PostComments />


### PR DESCRIPTION
Refactor out the arrow button and used it in post card and new button
Update code highlight themes for better accessibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a "Scroll to Top" button that appears after scrolling and allows users to quickly return to the top of blog posts.

- **Improvements**
  - Enhanced blog post layout by adding the new "Scroll to Top" feature.
  - Improved semantic HTML structure and simplified styling in post cards.
  - Updated header scroll behavior for cleaner performance.
  - Added better positioning to prose content for layout consistency.

- **Style**
  - Updated markdown syntax highlighting themes for improved code readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->